### PR TITLE
Update three and canvas versions

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 /.git/*
 /lib/*
+src/CanvasRenderer.js

--- a/lib/CanvasRenderer.js
+++ b/lib/CanvasRenderer.js
@@ -1,0 +1,903 @@
+'use strict';
+
+/**
+ * @author mrdoob / http://mrdoob.com/
+ */
+
+THREE.SpriteCanvasMaterial = function (parameters) {
+  THREE.Material.call(this);
+
+  this.type = 'SpriteCanvasMaterial';
+
+  this.color = new THREE.Color(0xffffff);
+  this.program = function () {};
+
+  this.setValues(parameters);
+};
+
+THREE.SpriteCanvasMaterial.prototype = Object.create(THREE.Material.prototype);
+THREE.SpriteCanvasMaterial.prototype.constructor = THREE.SpriteCanvasMaterial;
+THREE.SpriteCanvasMaterial.prototype.isSpriteCanvasMaterial = true;
+
+THREE.SpriteCanvasMaterial.prototype.clone = function () {
+  const material = new THREE.SpriteCanvasMaterial();
+
+  material.copy(this);
+  material.color.copy(this.color);
+  material.program = this.program;
+
+  return material;
+};
+
+//
+
+THREE.CanvasRenderer = function (parameters) {
+  console.log('THREE.CanvasRenderer', THREE.REVISION);
+
+  parameters = parameters || {};
+
+  let _this = this,
+      _renderData,
+      _elements,
+      _lights,
+      _projector = new THREE.Projector(),
+      _canvas = parameters.canvas !== undefined ? parameters.canvas : document.createElement('canvas'),
+      _canvasWidth = _canvas.width,
+      _canvasHeight = _canvas.height,
+      _canvasWidthHalf = Math.floor(_canvasWidth / 2),
+      _canvasHeightHalf = Math.floor(_canvasHeight / 2),
+      _viewportX = 0,
+      _viewportY = 0,
+      _viewportWidth = _canvasWidth,
+      _viewportHeight = _canvasHeight,
+      _pixelRatio = 1,
+      _context = _canvas.getContext('2d', {
+    alpha: parameters.alpha === true
+  }),
+      _clearColor = new THREE.Color(0x000000),
+      _clearAlpha = parameters.alpha === true ? 0 : 1,
+      _contextGlobalAlpha = 1,
+      _contextGlobalCompositeOperation = 0,
+      _contextStrokeStyle = null,
+      _contextFillStyle = null,
+      _contextLineWidth = null,
+      _contextLineCap = null,
+      _contextLineJoin = null,
+      _contextLineDash = [],
+      _v1,
+      _v2,
+      _v3,
+      _v1x,
+      _v1y,
+      _v2x,
+      _v2y,
+      _v3x,
+      _v3y,
+      _color = new THREE.Color(),
+      _diffuseColor = new THREE.Color(),
+      _emissiveColor = new THREE.Color(),
+      _lightColor = new THREE.Color(),
+      _patterns = {},
+      _uvs,
+      _uv1x,
+      _uv1y,
+      _uv2x,
+      _uv2y,
+      _uv3x,
+      _uv3y,
+      _clipBox = new THREE.Box2(),
+      _clearBox = new THREE.Box2(),
+      _elemBox = new THREE.Box2(),
+      _ambientLight = new THREE.Color(),
+      _directionalLights = new THREE.Color(),
+      _pointLights = new THREE.Color(),
+      _vector3 = new THREE.Vector3(),
+      // Needed for PointLight
+  _centroid = new THREE.Vector3(),
+      _normal = new THREE.Vector3(),
+      _normalViewMatrix = new THREE.Matrix3();
+
+  /* TODO
+  _canvas.mozImageSmoothingEnabled = false;
+  _canvas.webkitImageSmoothingEnabled = false;
+  _canvas.msImageSmoothingEnabled = false;
+  _canvas.imageSmoothingEnabled = false;
+  */
+
+  // dash+gap fallbacks for Firefox and everything else
+
+  if (_context.setLineDash === undefined) {
+    _context.setLineDash = function () {};
+  }
+
+  this.domElement = _canvas;
+
+  this.autoClear = true;
+  this.sortObjects = true;
+  this.sortElements = true;
+
+  this.info = {
+
+    render: {
+
+      vertices: 0,
+      faces: 0
+
+    }
+
+  };
+
+  // API
+
+  this.getContext = function () {
+    return _context;
+  };
+
+  this.getContextAttributes = function () {
+    return _context.getContextAttributes();
+  };
+
+  this.getPixelRatio = function () {
+    return _pixelRatio;
+  };
+
+  this.setPixelRatio = function (value) {
+    if (value !== undefined) _pixelRatio = value;
+  };
+
+  this.setSize = function (width, height, updateStyle) {
+    _canvasWidth = width * _pixelRatio;
+    _canvasHeight = height * _pixelRatio;
+
+    _canvas.width = _canvasWidth;
+    _canvas.height = _canvasHeight;
+
+    _canvasWidthHalf = Math.floor(_canvasWidth / 2);
+    _canvasHeightHalf = Math.floor(_canvasHeight / 2);
+
+    if (updateStyle !== false) {
+      _canvas.style.width = `${width}px`;
+      _canvas.style.height = `${height}px`;
+    }
+
+    _clipBox.min.set(-_canvasWidthHalf, -_canvasHeightHalf);
+    _clipBox.max.set(_canvasWidthHalf, _canvasHeightHalf);
+
+    _clearBox.min.set(-_canvasWidthHalf, -_canvasHeightHalf);
+    _clearBox.max.set(_canvasWidthHalf, _canvasHeightHalf);
+
+    _contextGlobalAlpha = 1;
+    _contextGlobalCompositeOperation = 0;
+    _contextStrokeStyle = null;
+    _contextFillStyle = null;
+    _contextLineWidth = null;
+    _contextLineCap = null;
+    _contextLineJoin = null;
+
+    this.setViewport(0, 0, width, height);
+  };
+
+  this.setViewport = function (x, y, width, height) {
+    _viewportX = x * _pixelRatio;
+    _viewportY = y * _pixelRatio;
+
+    _viewportWidth = width * _pixelRatio;
+    _viewportHeight = height * _pixelRatio;
+  };
+
+  this.setScissor = function () {};
+  this.setScissorTest = function () {};
+
+  this.setClearColor = function (color, alpha) {
+    _clearColor.set(color);
+    _clearAlpha = alpha !== undefined ? alpha : 1;
+
+    _clearBox.min.set(-_canvasWidthHalf, -_canvasHeightHalf);
+    _clearBox.max.set(_canvasWidthHalf, _canvasHeightHalf);
+  };
+
+  this.setClearColorHex = function (hex, alpha) {
+    console.warn('THREE.CanvasRenderer: .setClearColorHex() is being removed. Use .setClearColor() instead.');
+    this.setClearColor(hex, alpha);
+  };
+
+  this.getClearColor = function () {
+    return _clearColor;
+  };
+
+  this.getClearAlpha = function () {
+    return _clearAlpha;
+  };
+
+  this.getMaxAnisotropy = function () {
+    return 0;
+  };
+
+  this.clear = function () {
+    if (_clearBox.isEmpty() === false) {
+      _clearBox.intersect(_clipBox);
+      _clearBox.expandByScalar(2);
+
+      _clearBox.min.x = _clearBox.min.x + _canvasWidthHalf;
+      _clearBox.min.y = -_clearBox.min.y + _canvasHeightHalf; // higher y value !
+      _clearBox.max.x = _clearBox.max.x + _canvasWidthHalf;
+      _clearBox.max.y = -_clearBox.max.y + _canvasHeightHalf; // lower y value !
+
+      if (_clearAlpha < 1) {
+        _context.clearRect(_clearBox.min.x | 0, _clearBox.max.y | 0, _clearBox.max.x - _clearBox.min.x | 0, _clearBox.min.y - _clearBox.max.y | 0);
+      }
+
+      if (_clearAlpha > 0) {
+        setOpacity(1);
+        setBlending(THREE.NormalBlending);
+
+        setFillStyle(`rgba(${Math.floor(_clearColor.r * 255)},${Math.floor(_clearColor.g * 255)},${Math.floor(_clearColor.b * 255)},${_clearAlpha})`);
+
+        _context.fillRect(_clearBox.min.x | 0, _clearBox.max.y | 0, _clearBox.max.x - _clearBox.min.x | 0, _clearBox.min.y - _clearBox.max.y | 0);
+      }
+
+      _clearBox.makeEmpty();
+    }
+  };
+
+  // compatibility
+
+  this.clearColor = function () {};
+  this.clearDepth = function () {};
+  this.clearStencil = function () {};
+
+  this.render = function (scene, camera) {
+    if (camera.isCamera === undefined) {
+      console.error('THREE.CanvasRenderer.render: camera is not an instance of THREE.Camera.');
+      return;
+    }
+
+    const background = scene.background;
+
+    if (background && background.isColor) {
+      setOpacity(1);
+      setBlending(THREE.NormalBlending);
+
+      setFillStyle(background.getStyle());
+      _context.fillRect(0, 0, _canvasWidth, _canvasHeight);
+    } else if (this.autoClear === true) {
+      this.clear();
+    }
+
+    _this.info.render.vertices = 0;
+    _this.info.render.faces = 0;
+
+    _context.setTransform(_viewportWidth / _canvasWidth, 0, 0, -_viewportHeight / _canvasHeight, _viewportX, _canvasHeight - _viewportY);
+    _context.translate(_canvasWidthHalf, _canvasHeightHalf);
+
+    _renderData = _projector.projectScene(scene, camera, this.sortObjects, this.sortElements);
+    _elements = _renderData.elements;
+    _lights = _renderData.lights;
+
+    _normalViewMatrix.getNormalMatrix(camera.matrixWorldInverse);
+
+    /* DEBUG
+    setFillStyle( 'rgba( 0, 255, 255, 0.5 )' );
+    _context.fillRect( _clipBox.min.x, _clipBox.min.y, _clipBox.max.x - _clipBox.min.x, _clipBox.max.y - _clipBox.min.y );
+    */
+
+    calculateLights();
+
+    for (let e = 0, el = _elements.length; e < el; e++) {
+      const element = _elements[e];
+
+      const material = element.material;
+
+      if (material === undefined || material.opacity === 0) continue;
+
+      _elemBox.makeEmpty();
+
+      if (element instanceof THREE.RenderableSprite) {
+        _v1 = element;
+        _v1.x *= _canvasWidthHalf;_v1.y *= _canvasHeightHalf;
+
+        renderSprite(_v1, element, material);
+      } else if (element instanceof THREE.RenderableLine) {
+        _v1 = element.v1;_v2 = element.v2;
+
+        _v1.positionScreen.x *= _canvasWidthHalf;_v1.positionScreen.y *= _canvasHeightHalf;
+        _v2.positionScreen.x *= _canvasWidthHalf;_v2.positionScreen.y *= _canvasHeightHalf;
+
+        _elemBox.setFromPoints([_v1.positionScreen, _v2.positionScreen]);
+
+        if (_clipBox.intersectsBox(_elemBox) === true) {
+          renderLine(_v1, _v2, element, material);
+        }
+      } else if (element instanceof THREE.RenderableFace) {
+        _v1 = element.v1;_v2 = element.v2;_v3 = element.v3;
+
+        if (_v1.positionScreen.z < -1 || _v1.positionScreen.z > 1) continue;
+        if (_v2.positionScreen.z < -1 || _v2.positionScreen.z > 1) continue;
+        if (_v3.positionScreen.z < -1 || _v3.positionScreen.z > 1) continue;
+
+        _v1.positionScreen.x *= _canvasWidthHalf;_v1.positionScreen.y *= _canvasHeightHalf;
+        _v2.positionScreen.x *= _canvasWidthHalf;_v2.positionScreen.y *= _canvasHeightHalf;
+        _v3.positionScreen.x *= _canvasWidthHalf;_v3.positionScreen.y *= _canvasHeightHalf;
+
+        if (material.overdraw > 0) {
+          expand(_v1.positionScreen, _v2.positionScreen, material.overdraw);
+          expand(_v2.positionScreen, _v3.positionScreen, material.overdraw);
+          expand(_v3.positionScreen, _v1.positionScreen, material.overdraw);
+        }
+
+        _elemBox.setFromPoints([_v1.positionScreen, _v2.positionScreen, _v3.positionScreen]);
+
+        if (_clipBox.intersectsBox(_elemBox) === true) {
+          renderFace3(_v1, _v2, _v3, 0, 1, 2, element, material);
+        }
+      }
+
+      /* DEBUG
+      setLineWidth( 1 );
+      setStrokeStyle( 'rgba( 0, 255, 0, 0.5 )' );
+      _context.strokeRect( _elemBox.min.x, _elemBox.min.y, _elemBox.max.x - _elemBox.min.x, _elemBox.max.y - _elemBox.min.y );
+      */
+
+      _clearBox.union(_elemBox);
+    }
+
+    /* DEBUG
+    setLineWidth( 1 );
+    setStrokeStyle( 'rgba( 255, 0, 0, 0.5 )' );
+    _context.strokeRect( _clearBox.min.x, _clearBox.min.y, _clearBox.max.x - _clearBox.min.x, _clearBox.max.y - _clearBox.min.y );
+    */
+
+    _context.setTransform(1, 0, 0, 1, 0, 0);
+  };
+
+  //
+
+  function calculateLights() {
+    _ambientLight.setRGB(0, 0, 0);
+    _directionalLights.setRGB(0, 0, 0);
+    _pointLights.setRGB(0, 0, 0);
+
+    for (let l = 0, ll = _lights.length; l < ll; l++) {
+      const light = _lights[l];
+      const lightColor = light.color;
+
+      if (light.isAmbientLight) {
+        _ambientLight.add(lightColor);
+      } else if (light.isDirectionalLight) {
+        // for sprites
+
+        _directionalLights.add(lightColor);
+      } else if (light.isPointLight) {
+        // for sprites
+
+        _pointLights.add(lightColor);
+      }
+    }
+  }
+
+  function calculateLight(position, normal, color) {
+    for (let l = 0, ll = _lights.length; l < ll; l++) {
+      const light = _lights[l];
+
+      _lightColor.copy(light.color);
+
+      if (light.isDirectionalLight) {
+        var lightPosition = _vector3.setFromMatrixPosition(light.matrixWorld).normalize();
+
+        var amount = normal.dot(lightPosition);
+
+        if (amount <= 0) continue;
+
+        amount *= light.intensity;
+
+        color.add(_lightColor.multiplyScalar(amount));
+      } else if (light.isPointLight) {
+        var lightPosition = _vector3.setFromMatrixPosition(light.matrixWorld);
+
+        var amount = normal.dot(_vector3.subVectors(lightPosition, position).normalize());
+
+        if (amount <= 0) continue;
+
+        amount *= light.distance == 0 ? 1 : 1 - Math.min(position.distanceTo(lightPosition) / light.distance, 1);
+
+        if (amount == 0) continue;
+
+        amount *= light.intensity;
+
+        color.add(_lightColor.multiplyScalar(amount));
+      }
+    }
+  }
+
+  function renderSprite(v1, element, material) {
+    setOpacity(material.opacity);
+    setBlending(material.blending);
+
+    const scaleX = element.scale.x * _canvasWidthHalf;
+    const scaleY = element.scale.y * _canvasHeightHalf;
+
+    const dist = Math.sqrt(scaleX * scaleX + scaleY * scaleY); // allow for rotated sprite
+    _elemBox.min.set(v1.x - dist, v1.y - dist);
+    _elemBox.max.set(v1.x + dist, v1.y + dist);
+
+    if (material.isSpriteMaterial) {
+      const texture = material.map;
+
+      if (texture !== null) {
+        let pattern = _patterns[texture.id];
+
+        if (pattern === undefined || pattern.version !== texture.version) {
+          pattern = textureToPattern(texture);
+          _patterns[texture.id] = pattern;
+        }
+
+        if (pattern.canvas !== undefined) {
+          setFillStyle(pattern.canvas);
+
+          const bitmap = texture.image;
+
+          const ox = bitmap.width * texture.offset.x;
+          const oy = bitmap.height * texture.offset.y;
+
+          const sx = bitmap.width * texture.repeat.x;
+          const sy = bitmap.height * texture.repeat.y;
+
+          const cx = scaleX / sx;
+          const cy = scaleY / sy;
+
+          _context.save();
+          _context.translate(v1.x, v1.y);
+          if (material.rotation !== 0) _context.rotate(material.rotation);
+          _context.translate(-scaleX / 2, -scaleY / 2);
+          _context.scale(cx, cy);
+          _context.translate(-ox, -oy);
+          _context.fillRect(ox, oy, sx, sy);
+          _context.restore();
+        }
+      } else {
+        // no texture
+
+        setFillStyle(material.color.getStyle());
+
+        _context.save();
+        _context.translate(v1.x, v1.y);
+        if (material.rotation !== 0) _context.rotate(material.rotation);
+        _context.scale(scaleX, -scaleY);
+        _context.fillRect(-0.5, -0.5, 1, 1);
+        _context.restore();
+      }
+    } else if (material.isSpriteCanvasMaterial) {
+      setStrokeStyle(material.color.getStyle());
+      setFillStyle(material.color.getStyle());
+
+      _context.save();
+      _context.translate(v1.x, v1.y);
+      if (material.rotation !== 0) _context.rotate(material.rotation);
+      _context.scale(scaleX, scaleY);
+
+      material.program(_context);
+
+      _context.restore();
+    } else if (material.isPointsMaterial) {
+      setFillStyle(material.color.getStyle());
+
+      _context.save();
+      _context.translate(v1.x, v1.y);
+      if (material.rotation !== 0) _context.rotate(material.rotation);
+      _context.scale(scaleX * material.size, -scaleY * material.size);
+      _context.fillRect(-0.5, -0.5, 1, 1);
+      _context.restore();
+    }
+
+    /* DEBUG
+    setStrokeStyle( 'rgb(255,255,0)' );
+    _context.beginPath();
+    _context.moveTo( v1.x - 10, v1.y );
+    _context.lineTo( v1.x + 10, v1.y );
+    _context.moveTo( v1.x, v1.y - 10 );
+    _context.lineTo( v1.x, v1.y + 10 );
+    _context.stroke();
+    */
+  }
+
+  function renderLine(v1, v2, element, material) {
+    setOpacity(material.opacity);
+    setBlending(material.blending);
+
+    _context.beginPath();
+    _context.moveTo(v1.positionScreen.x, v1.positionScreen.y);
+    _context.lineTo(v2.positionScreen.x, v2.positionScreen.y);
+
+    if (material.isLineBasicMaterial) {
+      setLineWidth(material.linewidth);
+      setLineCap(material.linecap);
+      setLineJoin(material.linejoin);
+
+      if (material.vertexColors !== THREE.VertexColors) {
+        setStrokeStyle(material.color.getStyle());
+      } else {
+        const colorStyle1 = element.vertexColors[0].getStyle();
+        const colorStyle2 = element.vertexColors[1].getStyle();
+
+        if (colorStyle1 === colorStyle2) {
+          setStrokeStyle(colorStyle1);
+        } else {
+          try {
+            var grad = _context.createLinearGradient(v1.positionScreen.x, v1.positionScreen.y, v2.positionScreen.x, v2.positionScreen.y);
+            grad.addColorStop(0, colorStyle1);
+            grad.addColorStop(1, colorStyle2);
+          } catch (exception) {
+            grad = colorStyle1;
+          }
+
+          setStrokeStyle(grad);
+        }
+      }
+
+      if (material.isLineDashedMaterial) {
+        setLineDash([material.dashSize, material.gapSize]);
+      }
+
+      _context.stroke();
+      _elemBox.expandByScalar(material.linewidth * 2);
+
+      if (material.isLineDashedMaterial) {
+        setLineDash([]);
+      }
+    }
+  }
+
+  function renderFace3(v1, v2, v3, uv1, uv2, uv3, element, material) {
+    _this.info.render.vertices += 3;
+    _this.info.render.faces++;
+
+    setOpacity(material.opacity);
+    setBlending(material.blending);
+
+    _v1x = v1.positionScreen.x;_v1y = v1.positionScreen.y;
+    _v2x = v2.positionScreen.x;_v2y = v2.positionScreen.y;
+    _v3x = v3.positionScreen.x;_v3y = v3.positionScreen.y;
+
+    drawTriangle(_v1x, _v1y, _v2x, _v2y, _v3x, _v3y);
+
+    if ((material.isMeshLambertMaterial || material.isMeshPhongMaterial || material.isMeshStandardMaterial) && material.map === null) {
+      _diffuseColor.copy(material.color);
+      _emissiveColor.copy(material.emissive);
+
+      if (material.vertexColors === THREE.FaceColors) {
+        _diffuseColor.multiply(element.color);
+      }
+
+      _color.copy(_ambientLight);
+
+      _centroid.copy(v1.positionWorld).add(v2.positionWorld).add(v3.positionWorld).divideScalar(3);
+
+      calculateLight(_centroid, element.normalModel, _color);
+
+      _color.multiply(_diffuseColor).add(_emissiveColor);
+
+      material.wireframe === true ? strokePath(_color, material.wireframeLinewidth, material.wireframeLinecap, material.wireframeLinejoin) : fillPath(_color);
+    } else if (material.isMeshBasicMaterial || material.isMeshLambertMaterial || material.isMeshPhongMaterial || material.isMeshStandardMaterial) {
+      if (material.map !== null) {
+        const mapping = material.map.mapping;
+
+        if (mapping === THREE.UVMapping) {
+          _uvs = element.uvs;
+          patternPath(_v1x, _v1y, _v2x, _v2y, _v3x, _v3y, _uvs[uv1].x, _uvs[uv1].y, _uvs[uv2].x, _uvs[uv2].y, _uvs[uv3].x, _uvs[uv3].y, material.map);
+        }
+      } else if (material.envMap !== null) {
+        if (material.envMap.mapping === THREE.SphericalReflectionMapping) {
+          _normal.copy(element.vertexNormalsModel[uv1]).applyMatrix3(_normalViewMatrix);
+          _uv1x = 0.5 * _normal.x + 0.5;
+          _uv1y = 0.5 * _normal.y + 0.5;
+
+          _normal.copy(element.vertexNormalsModel[uv2]).applyMatrix3(_normalViewMatrix);
+          _uv2x = 0.5 * _normal.x + 0.5;
+          _uv2y = 0.5 * _normal.y + 0.5;
+
+          _normal.copy(element.vertexNormalsModel[uv3]).applyMatrix3(_normalViewMatrix);
+          _uv3x = 0.5 * _normal.x + 0.5;
+          _uv3y = 0.5 * _normal.y + 0.5;
+
+          patternPath(_v1x, _v1y, _v2x, _v2y, _v3x, _v3y, _uv1x, _uv1y, _uv2x, _uv2y, _uv3x, _uv3y, material.envMap);
+        }
+      } else {
+        _color.copy(material.color);
+
+        if (material.vertexColors === THREE.FaceColors) {
+          _color.multiply(element.color);
+        }
+
+        material.wireframe === true ? strokePath(_color, material.wireframeLinewidth, material.wireframeLinecap, material.wireframeLinejoin) : fillPath(_color);
+      }
+    } else if (material.isMeshNormalMaterial) {
+      _normal.copy(element.normalModel).applyMatrix3(_normalViewMatrix);
+
+      _color.setRGB(_normal.x, _normal.y, _normal.z).multiplyScalar(0.5).addScalar(0.5);
+
+      material.wireframe === true ? strokePath(_color, material.wireframeLinewidth, material.wireframeLinecap, material.wireframeLinejoin) : fillPath(_color);
+    } else {
+      _color.setRGB(1, 1, 1);
+
+      material.wireframe === true ? strokePath(_color, material.wireframeLinewidth, material.wireframeLinecap, material.wireframeLinejoin) : fillPath(_color);
+    }
+  }
+
+  //
+
+  function drawTriangle(x0, y0, x1, y1, x2, y2) {
+    _context.beginPath();
+    _context.moveTo(x0, y0);
+    _context.lineTo(x1, y1);
+    _context.lineTo(x2, y2);
+    _context.closePath();
+  }
+
+  function strokePath(color, linewidth, linecap, linejoin) {
+    setLineWidth(linewidth);
+    setLineCap(linecap);
+    setLineJoin(linejoin);
+    setStrokeStyle(color.getStyle());
+
+    _context.stroke();
+
+    _elemBox.expandByScalar(linewidth * 2);
+  }
+
+  function fillPath(color) {
+    setFillStyle(color.getStyle());
+    _context.fill();
+  }
+
+  function textureToPattern(texture) {
+    if (texture.version === 0 || texture instanceof THREE.CompressedTexture || texture instanceof THREE.DataTexture) {
+      return {
+        canvas: undefined,
+        version: texture.version
+      };
+    }
+
+    const image = texture.image;
+
+    if (image.complete === false) {
+      return {
+        canvas: undefined,
+        version: 0
+      };
+    }
+
+    const repeatX = texture.wrapS === THREE.RepeatWrapping || texture.wrapS === THREE.MirroredRepeatWrapping;
+    const repeatY = texture.wrapT === THREE.RepeatWrapping || texture.wrapT === THREE.MirroredRepeatWrapping;
+
+    const mirrorX = texture.wrapS === THREE.MirroredRepeatWrapping;
+    const mirrorY = texture.wrapT === THREE.MirroredRepeatWrapping;
+
+    //
+
+    const canvas = document.createElement('canvas');
+    canvas.width = image.width * (mirrorX ? 2 : 1);
+    canvas.height = image.height * (mirrorY ? 2 : 1);
+
+    const context = canvas.getContext('2d');
+    context.setTransform(1, 0, 0, -1, 0, image.height);
+    context.drawImage(image, 0, 0);
+
+    if (mirrorX === true) {
+      context.setTransform(-1, 0, 0, -1, image.width, image.height);
+      context.drawImage(image, -image.width, 0);
+    }
+
+    if (mirrorY === true) {
+      context.setTransform(1, 0, 0, 1, 0, 0);
+      context.drawImage(image, 0, image.height);
+    }
+
+    if (mirrorX === true && mirrorY === true) {
+      context.setTransform(-1, 0, 0, 1, image.width, 0);
+      context.drawImage(image, -image.width, image.height);
+    }
+
+    let repeat = 'no-repeat';
+
+    if (repeatX === true && repeatY === true) {
+      repeat = 'repeat';
+    } else if (repeatX === true) {
+      repeat = 'repeat-x';
+    } else if (repeatY === true) {
+      repeat = 'repeat-y';
+    }
+
+    const pattern = _context.createPattern(canvas, repeat);
+
+    if (texture.onUpdate) texture.onUpdate(texture);
+
+    return {
+      canvas: pattern,
+      version: texture.version
+    };
+  }
+
+  function patternPath(x0, y0, x1, y1, x2, y2, u0, v0, u1, v1, u2, v2, texture) {
+    let pattern = _patterns[texture.id];
+
+    if (pattern === undefined || pattern.version !== texture.version) {
+      pattern = textureToPattern(texture);
+      _patterns[texture.id] = pattern;
+    }
+
+    if (pattern.canvas !== undefined) {
+      setFillStyle(pattern.canvas);
+    } else {
+      setFillStyle('rgba( 0, 0, 0, 1)');
+      _context.fill();
+      return;
+    }
+
+    // http://extremelysatisfactorytotalitarianism.com/blog/?p=2120
+
+    let a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        det,
+        idet,
+        offsetX = texture.offset.x / texture.repeat.x,
+        offsetY = texture.offset.y / texture.repeat.y,
+        width = texture.image.width * texture.repeat.x,
+        height = texture.image.height * texture.repeat.y;
+
+    u0 = (u0 + offsetX) * width;
+    v0 = (v0 + offsetY) * height;
+
+    u1 = (u1 + offsetX) * width;
+    v1 = (v1 + offsetY) * height;
+
+    u2 = (u2 + offsetX) * width;
+    v2 = (v2 + offsetY) * height;
+
+    x1 -= x0;y1 -= y0;
+    x2 -= x0;y2 -= y0;
+
+    u1 -= u0;v1 -= v0;
+    u2 -= u0;v2 -= v0;
+
+    det = u1 * v2 - u2 * v1;
+
+    if (det === 0) return;
+
+    idet = 1 / det;
+
+    a = (v2 * x1 - v1 * x2) * idet;
+    b = (v2 * y1 - v1 * y2) * idet;
+    c = (u1 * x2 - u2 * x1) * idet;
+    d = (u1 * y2 - u2 * y1) * idet;
+
+    e = x0 - a * u0 - c * v0;
+    f = y0 - b * u0 - d * v0;
+
+    _context.save();
+    _context.transform(a, b, c, d, e, f);
+    _context.fill();
+    _context.restore();
+  }
+
+  /*
+  function clipImage( x0, y0, x1, y1, x2, y2, u0, v0, u1, v1, u2, v2, image ) {
+  	// http://extremelysatisfactorytotalitarianism.com/blog/?p=2120
+  	var a, b, c, d, e, f, det, idet,
+  width = image.width - 1,
+  height = image.height - 1;
+  	u0 *= width; v0 *= height;
+  u1 *= width; v1 *= height;
+  u2 *= width; v2 *= height;
+  	x1 -= x0; y1 -= y0;
+  x2 -= x0; y2 -= y0;
+  	u1 -= u0; v1 -= v0;
+  u2 -= u0; v2 -= v0;
+  	det = u1 * v2 - u2 * v1;
+  	idet = 1 / det;
+  	a = ( v2 * x1 - v1 * x2 ) * idet;
+  b = ( v2 * y1 - v1 * y2 ) * idet;
+  c = ( u1 * x2 - u2 * x1 ) * idet;
+  d = ( u1 * y2 - u2 * y1 ) * idet;
+  	e = x0 - a * u0 - c * v0;
+  f = y0 - b * u0 - d * v0;
+  	_context.save();
+  _context.transform( a, b, c, d, e, f );
+  _context.clip();
+  _context.drawImage( image, 0, 0 );
+  _context.restore();
+  }
+  */
+
+  // Hide anti-alias gaps
+
+  function expand(v1, v2, pixels) {
+    let x = v2.x - v1.x,
+        y = v2.y - v1.y,
+        det = x * x + y * y,
+        idet;
+
+    if (det === 0) return;
+
+    idet = pixels / Math.sqrt(det);
+
+    x *= idet;y *= idet;
+
+    v2.x += x;v2.y += y;
+    v1.x -= x;v1.y -= y;
+  }
+
+  // Context cached methods.
+
+  function setOpacity(value) {
+    if (_contextGlobalAlpha !== value) {
+      _context.globalAlpha = value;
+      _contextGlobalAlpha = value;
+    }
+  }
+
+  function setBlending(value) {
+    if (_contextGlobalCompositeOperation !== value) {
+      if (value === THREE.NormalBlending) {
+        _context.globalCompositeOperation = 'source-over';
+      } else if (value === THREE.AdditiveBlending) {
+        _context.globalCompositeOperation = 'lighter';
+      } else if (value === THREE.SubtractiveBlending) {
+        _context.globalCompositeOperation = 'darker';
+      } else if (value === THREE.MultiplyBlending) {
+        _context.globalCompositeOperation = 'multiply';
+      }
+
+      _contextGlobalCompositeOperation = value;
+    }
+  }
+
+  function setLineWidth(value) {
+    if (_contextLineWidth !== value) {
+      _context.lineWidth = value;
+      _contextLineWidth = value;
+    }
+  }
+
+  function setLineCap(value) {
+    // "butt", "round", "square"
+
+    if (_contextLineCap !== value) {
+      _context.lineCap = value;
+      _contextLineCap = value;
+    }
+  }
+
+  function setLineJoin(value) {
+    // "round", "bevel", "miter"
+
+    if (_contextLineJoin !== value) {
+      _context.lineJoin = value;
+      _contextLineJoin = value;
+    }
+  }
+
+  function setStrokeStyle(value) {
+    if (_contextStrokeStyle !== value) {
+      _context.strokeStyle = value;
+      _contextStrokeStyle = value;
+    }
+  }
+
+  function setFillStyle(value) {
+    if (_contextFillStyle !== value) {
+      _context.fillStyle = value;
+      _contextFillStyle = value;
+    }
+  }
+
+  function setLineDash(value) {
+    if (_contextLineDash.length !== value.length) {
+      _context.setLineDash(value);
+      _contextLineDash = value;
+    }
+  }
+};

--- a/lib/three.js
+++ b/lib/three.js
@@ -4,7 +4,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 global.THREE = require('three');
-require('three/examples/js/renderers/CanvasRenderer');
+require('./CanvasRenderer');
 require('three/examples/js/renderers/Projector');
 
 exports.default = global.THREE;

--- a/lib/toCanvas.js
+++ b/lib/toCanvas.js
@@ -11,8 +11,6 @@ exports.default = toCanvas;
 
 var _canvas = require('canvas');
 
-var _canvas2 = _interopRequireDefault(_canvas);
-
 var _three = require('./three');
 
 var _three2 = _interopRequireDefault(_three);
@@ -45,7 +43,7 @@ function toCanvas(scene, options) {
     camera.lookAt(outScene.position);
   }
 
-  const canvas = new _canvas2.default(opts.width, opts.height);
+  const canvas = (0, _canvas.createCanvas)(opts.width, opts.height);
   canvas.style = {}; // dummy shim to prevent errors during render.setSize
   const renderer = new _three2.default.CanvasRenderer({ canvas });
   renderer.setSize(opts.width, opts.height);

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,11 @@
       "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
       "dev": true
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
     "acorn": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
@@ -137,8 +142,7 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
@@ -164,6 +168,20 @@
       "dev": true,
       "requires": {
         "default-require-extensions": "1.0.0"
+      }
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "argparse": {
@@ -1247,8 +1265,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -1347,7 +1364,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -1472,11 +1488,13 @@
       "dev": true
     },
     "canvas": {
-      "version": "1.6.10",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-1.6.10.tgz",
-      "integrity": "sha512-wd97ZrUfLYWjQ0qcJGiM44anXB+RviRu3DETpPIS4Sf7JzhP9PawwHdZOlx8sufcsRSeWuQe93qaCtwvK1jWXQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.5.0.tgz",
+      "integrity": "sha512-wwRz2cLMgb9d+rnotOJCoc04Bzj3aJMpWc6JxAD6lP7bYz0ldcn0sKddoZ0vhD5T8HBxrK+XmRDJb68/2VqARw==",
       "requires": {
-        "nan": "2.10.0"
+        "nan": "2.14.0",
+        "node-pre-gyp": "0.11.0",
+        "simple-get": "3.0.3"
       }
     },
     "capture-exit": {
@@ -1541,6 +1559,11 @@
         "path-is-absolute": "1.0.1",
         "readdirp": "2.1.0"
       }
+    },
+    "chownr": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+      "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
     },
     "ci-info": {
       "version": "1.1.3",
@@ -1628,8 +1651,7 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -1686,8 +1708,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -1700,6 +1721,11 @@
         "readable-stream": "2.3.6",
         "typedarray": "0.0.6"
       }
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "contains-path": {
       "version": "0.1.0",
@@ -1728,8 +1754,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "5.1.0",
@@ -1823,6 +1848,19 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "1.0.1"
+      }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1923,6 +1961,11 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
@@ -1931,6 +1974,11 @@
       "requires": {
         "repeating": "2.0.1"
       }
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -2670,6 +2718,14 @@
         "map-cache": "0.2.2"
       }
     },
+    "fs-minipass": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+      "requires": {
+        "minipass": "2.3.5"
+      }
+    },
     "fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -2679,8 +2735,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.3",
@@ -2689,7 +2744,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.10.0",
+        "nan": "2.14.0",
         "node-pre-gyp": "0.9.1"
       },
       "dependencies": {
@@ -3223,6 +3278,41 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.3"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
+      }
+    },
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -3260,7 +3350,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -3390,6 +3479,11 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
     "has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
@@ -3508,7 +3602,6 @@
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-      "dev": true,
       "requires": {
         "safer-buffer": "2.1.2"
       }
@@ -3518,6 +3611,14 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
       "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
       "dev": true
+    },
+    "ignore-walk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "requires": {
+        "minimatch": "3.0.4"
+      }
     },
     "import-local": {
       "version": "1.0.0",
@@ -3550,7 +3651,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -3559,8 +3659,12 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
       "version": "3.3.0",
@@ -3773,8 +3877,7 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-generator-fn": {
       "version": "1.0.0",
@@ -3924,8 +4027,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -5161,11 +5263,15 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "1.1.11"
       }
@@ -5173,8 +5279,31 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "minipass": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "requires": {
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.3"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "requires": {
+        "minipass": "2.3.5"
+      }
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -5201,7 +5330,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -5219,9 +5347,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "nanomatch": {
       "version": "1.2.9",
@@ -5269,6 +5397,31 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "needle": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
+      "requires": {
+        "debug": "3.2.6",
+        "iconv-lite": "0.4.23",
+        "sax": "1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -5297,6 +5450,32 @@
         "which": "1.3.0"
       }
     },
+    "node-pre-gyp": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
+      "integrity": "sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==",
+      "requires": {
+        "detect-libc": "1.0.3",
+        "mkdirp": "0.5.1",
+        "needle": "2.4.0",
+        "nopt": "4.0.1",
+        "npm-packlist": "1.4.4",
+        "npmlog": "4.1.2",
+        "rc": "1.2.8",
+        "rimraf": "2.6.2",
+        "semver": "5.5.0",
+        "tar": "4.4.10"
+      }
+    },
+    "nopt": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+      "requires": {
+        "abbrev": "1.1.1",
+        "osenv": "0.1.5"
+      }
+    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -5318,6 +5497,20 @@
         "remove-trailing-separator": "1.1.0"
       }
     },
+    "npm-bundled": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+      "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g=="
+    },
+    "npm-packlist": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.4.tgz",
+      "integrity": "sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==",
+      "requires": {
+        "ignore-walk": "3.0.1",
+        "npm-bundled": "1.0.6"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -5327,11 +5520,21 @@
         "path-key": "2.0.1"
       }
     },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "1.1.5",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
+      }
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwmatcher": {
       "version": "1.4.4",
@@ -5348,8 +5551,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -5437,7 +5639,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -5486,8 +5687,7 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
       "version": "2.1.0",
@@ -5503,8 +5703,16 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
     },
     "output-file-sync": {
       "version": "1.1.2",
@@ -5589,8 +5797,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -5759,8 +5966,7 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "dev": true
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress": {
       "version": "2.0.0",
@@ -5831,6 +6037,24 @@
         }
       }
     },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -5877,7 +6101,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -6159,7 +6382,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
       "requires": {
         "glob": "7.1.2"
       }
@@ -6197,8 +6419,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -6212,8 +6433,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "2.5.2",
@@ -6527,20 +6747,17 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-      "dev": true
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-immediate-shim": {
       "version": "1.0.1",
@@ -6602,8 +6819,22 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+    },
+    "simple-get": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.0.3.tgz",
+      "integrity": "sha512-Wvre/Jq5vgoz31Z9stYWPLn0PqRqmBDpFSdypAnHu5AvRVCYPRYGnvryNLiXu8GOBNDH82J2FRHUGMjjHUpXFw==",
+      "requires": {
+        "decompress-response": "3.3.0",
+        "once": "1.4.0",
+        "simple-concat": "1.0.0"
+      }
     },
     "slash": {
       "version": "1.0.0",
@@ -6898,7 +7129,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
@@ -6907,14 +7137,12 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -6925,7 +7153,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.2"
       }
@@ -6940,7 +7167,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -6963,8 +7189,7 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
       "version": "2.0.0",
@@ -7020,6 +7245,27 @@
           "requires": {
             "has-flag": "3.0.0"
           }
+        }
+      }
+    },
+    "tar": {
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+      "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
+      "requires": {
+        "chownr": "1.1.2",
+        "fs-minipass": "1.2.6",
+        "minipass": "2.3.5",
+        "minizlib": "1.2.1",
+        "mkdirp": "0.5.1",
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.3"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
     },
@@ -7319,9 +7565,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.92.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.92.0.tgz",
-      "integrity": "sha1-jT0fWviQ5i2n9MtF0gwJ+lEFfc0="
+      "version": "0.106.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.106.2.tgz",
+      "integrity": "sha512-4Tlx43uoxnIaZFW2Bzkd1rXsatvVHEWAZJy8LuE+s6Q8c66ogNnhfq1bHiBKPAnXP230LD11H/ScIZc2LZMviA=="
     },
     "throat": {
       "version": "4.1.0",
@@ -7614,8 +7860,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.0",
@@ -7760,6 +8005,14 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "requires": {
+        "string-width": "2.1.1"
+      }
+    },
     "window-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
@@ -7808,8 +8061,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "canvas": "^1.6.10",
-    "three": "^0.92.0"
+    "three": "^0.106.2",
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "preversion": "npm run build && git add -A lib/ && npm test"
   },
   "dependencies": {
-    "canvas": "^1.6.10",
     "three": "^0.106.2",
+    "canvas": "^2.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/CanvasRenderer.js
+++ b/src/CanvasRenderer.js
@@ -1,0 +1,962 @@
+/**
+ * @author mrdoob / http://mrdoob.com/
+ */
+
+THREE.SpriteCanvasMaterial = function (parameters) {
+  THREE.Material.call(this);
+
+  this.type = 'SpriteCanvasMaterial';
+
+  this.color = new THREE.Color(0xffffff);
+  this.program = function () {};
+
+  this.setValues(parameters);
+};
+
+THREE.SpriteCanvasMaterial.prototype = Object.create(THREE.Material.prototype);
+THREE.SpriteCanvasMaterial.prototype.constructor = THREE.SpriteCanvasMaterial;
+THREE.SpriteCanvasMaterial.prototype.isSpriteCanvasMaterial = true;
+
+THREE.SpriteCanvasMaterial.prototype.clone = function () {
+  const material = new THREE.SpriteCanvasMaterial();
+
+  material.copy(this);
+  material.color.copy(this.color);
+  material.program = this.program;
+
+  return material;
+};
+
+//
+
+THREE.CanvasRenderer = function (parameters) {
+  console.log('THREE.CanvasRenderer', THREE.REVISION);
+
+  parameters = parameters || {};
+
+  let _this = this,
+    _renderData,
+    _elements,
+    _lights,
+    _projector = new THREE.Projector(),
+
+    _canvas = parameters.canvas !== undefined
+				 ? parameters.canvas
+				 : document.createElement('canvas'),
+
+    _canvasWidth = _canvas.width,
+    _canvasHeight = _canvas.height,
+    _canvasWidthHalf = Math.floor(_canvasWidth / 2),
+    _canvasHeightHalf = Math.floor(_canvasHeight / 2),
+
+    _viewportX = 0,
+    _viewportY = 0,
+    _viewportWidth = _canvasWidth,
+    _viewportHeight = _canvasHeight,
+
+    _pixelRatio = 1,
+
+    _context = _canvas.getContext('2d', {
+      alpha: parameters.alpha === true,
+    }),
+
+    _clearColor = new THREE.Color(0x000000),
+    _clearAlpha = parameters.alpha === true ? 0 : 1,
+
+    _contextGlobalAlpha = 1,
+    _contextGlobalCompositeOperation = 0,
+    _contextStrokeStyle = null,
+    _contextFillStyle = null,
+    _contextLineWidth = null,
+    _contextLineCap = null,
+    _contextLineJoin = null,
+    _contextLineDash = [],
+
+    _v1,
+    _v2,
+    _v3,
+
+    _v1x,
+    _v1y,
+    _v2x,
+    _v2y,
+    _v3x,
+    _v3y,
+
+    _color = new THREE.Color(),
+
+    _diffuseColor = new THREE.Color(),
+    _emissiveColor = new THREE.Color(),
+
+    _lightColor = new THREE.Color(),
+
+    _patterns = {},
+
+    _uvs,
+    _uv1x,
+    _uv1y,
+    _uv2x,
+    _uv2y,
+    _uv3x,
+    _uv3y,
+
+    _clipBox = new THREE.Box2(),
+    _clearBox = new THREE.Box2(),
+    _elemBox = new THREE.Box2(),
+
+    _ambientLight = new THREE.Color(),
+    _directionalLights = new THREE.Color(),
+    _pointLights = new THREE.Color(),
+
+    _vector3 = new THREE.Vector3(), // Needed for PointLight
+    _centroid = new THREE.Vector3(),
+    _normal = new THREE.Vector3(),
+    _normalViewMatrix = new THREE.Matrix3();
+
+  /* TODO
+	_canvas.mozImageSmoothingEnabled = false;
+	_canvas.webkitImageSmoothingEnabled = false;
+	_canvas.msImageSmoothingEnabled = false;
+	_canvas.imageSmoothingEnabled = false;
+	*/
+
+  // dash+gap fallbacks for Firefox and everything else
+
+  if (_context.setLineDash === undefined) {
+    _context.setLineDash = function () {};
+  }
+
+  this.domElement = _canvas;
+
+  this.autoClear = true;
+  this.sortObjects = true;
+  this.sortElements = true;
+
+  this.info = {
+
+    render: {
+
+      vertices: 0,
+      faces: 0,
+
+    },
+
+  };
+
+  // API
+
+  this.getContext = function () {
+    return _context;
+  };
+
+  this.getContextAttributes = function () {
+    return _context.getContextAttributes();
+  };
+
+  this.getPixelRatio = function () {
+    return _pixelRatio;
+  };
+
+  this.setPixelRatio = function (value) {
+    if (value !== undefined) _pixelRatio = value;
+  };
+
+  this.setSize = function (width, height, updateStyle) {
+    _canvasWidth = width * _pixelRatio;
+    _canvasHeight = height * _pixelRatio;
+
+    _canvas.width = _canvasWidth;
+    _canvas.height = _canvasHeight;
+
+    _canvasWidthHalf = Math.floor(_canvasWidth / 2);
+    _canvasHeightHalf = Math.floor(_canvasHeight / 2);
+
+    if (updateStyle !== false) {
+      _canvas.style.width = `${width}px`;
+      _canvas.style.height = `${height}px`;
+    }
+
+    _clipBox.min.set(-_canvasWidthHalf, -_canvasHeightHalf);
+    _clipBox.max.set(_canvasWidthHalf, _canvasHeightHalf);
+
+    _clearBox.min.set(-_canvasWidthHalf, -_canvasHeightHalf);
+    _clearBox.max.set(_canvasWidthHalf, _canvasHeightHalf);
+
+    _contextGlobalAlpha = 1;
+    _contextGlobalCompositeOperation = 0;
+    _contextStrokeStyle = null;
+    _contextFillStyle = null;
+    _contextLineWidth = null;
+    _contextLineCap = null;
+    _contextLineJoin = null;
+
+    this.setViewport(0, 0, width, height);
+  };
+
+  this.setViewport = function (x, y, width, height) {
+    _viewportX = x * _pixelRatio;
+    _viewportY = y * _pixelRatio;
+
+    _viewportWidth = width * _pixelRatio;
+    _viewportHeight = height * _pixelRatio;
+  };
+
+  this.setScissor = function () {};
+  this.setScissorTest = function () {};
+
+  this.setClearColor = function (color, alpha) {
+    _clearColor.set(color);
+    _clearAlpha = alpha !== undefined ? alpha : 1;
+
+    _clearBox.min.set(-_canvasWidthHalf, -_canvasHeightHalf);
+    _clearBox.max.set(_canvasWidthHalf, _canvasHeightHalf);
+  };
+
+  this.setClearColorHex = function (hex, alpha) {
+    console.warn('THREE.CanvasRenderer: .setClearColorHex() is being removed. Use .setClearColor() instead.');
+    this.setClearColor(hex, alpha);
+  };
+
+  this.getClearColor = function () {
+    return _clearColor;
+  };
+
+  this.getClearAlpha = function () {
+    return _clearAlpha;
+  };
+
+  this.getMaxAnisotropy = function () {
+    return 0;
+  };
+
+  this.clear = function () {
+    if (_clearBox.isEmpty() === false) {
+      _clearBox.intersect(_clipBox);
+      _clearBox.expandByScalar(2);
+
+      _clearBox.min.x = _clearBox.min.x + _canvasWidthHalf;
+      _clearBox.min.y = -_clearBox.min.y + _canvasHeightHalf;		// higher y value !
+      _clearBox.max.x = _clearBox.max.x + _canvasWidthHalf;
+      _clearBox.max.y = -_clearBox.max.y + _canvasHeightHalf;		// lower y value !
+
+      if (_clearAlpha < 1) {
+        _context.clearRect(
+          _clearBox.min.x | 0,
+          _clearBox.max.y | 0,
+          (_clearBox.max.x - _clearBox.min.x) | 0,
+          (_clearBox.min.y - _clearBox.max.y) | 0,
+        );
+      }
+
+      if (_clearAlpha > 0) {
+        setOpacity(1);
+        setBlending(THREE.NormalBlending);
+
+        setFillStyle(`rgba(${Math.floor(_clearColor.r * 255)},${Math.floor(_clearColor.g * 255)},${Math.floor(_clearColor.b * 255)},${_clearAlpha})`);
+
+        _context.fillRect(
+          _clearBox.min.x | 0,
+          _clearBox.max.y | 0,
+          (_clearBox.max.x - _clearBox.min.x) | 0,
+          (_clearBox.min.y - _clearBox.max.y) | 0,
+        );
+      }
+
+      _clearBox.makeEmpty();
+    }
+  };
+
+  // compatibility
+
+  this.clearColor = function () {};
+  this.clearDepth = function () {};
+  this.clearStencil = function () {};
+
+  this.render = function (scene, camera) {
+    if (camera.isCamera === undefined) {
+      console.error('THREE.CanvasRenderer.render: camera is not an instance of THREE.Camera.');
+      return;
+    }
+
+    const background = scene.background;
+
+    if (background && background.isColor) {
+      setOpacity(1);
+      setBlending(THREE.NormalBlending);
+
+      setFillStyle(background.getStyle());
+      _context.fillRect(0, 0, _canvasWidth, _canvasHeight);
+    } else if (this.autoClear === true) {
+      this.clear();
+    }
+
+    _this.info.render.vertices = 0;
+    _this.info.render.faces = 0;
+
+    _context.setTransform(_viewportWidth / _canvasWidth, 0, 0, -_viewportHeight / _canvasHeight, _viewportX, _canvasHeight - _viewportY);
+    _context.translate(_canvasWidthHalf, _canvasHeightHalf);
+
+    _renderData = _projector.projectScene(scene, camera, this.sortObjects, this.sortElements);
+    _elements = _renderData.elements;
+    _lights = _renderData.lights;
+
+    _normalViewMatrix.getNormalMatrix(camera.matrixWorldInverse);
+
+    /* DEBUG
+		setFillStyle( 'rgba( 0, 255, 255, 0.5 )' );
+		_context.fillRect( _clipBox.min.x, _clipBox.min.y, _clipBox.max.x - _clipBox.min.x, _clipBox.max.y - _clipBox.min.y );
+		*/
+
+    calculateLights();
+
+    for (let e = 0, el = _elements.length; e < el; e++) {
+      const element = _elements[e];
+
+      const material = element.material;
+
+      if (material === undefined || material.opacity === 0) continue;
+
+      _elemBox.makeEmpty();
+
+      if (element instanceof THREE.RenderableSprite) {
+        _v1 = element;
+        _v1.x *= _canvasWidthHalf; _v1.y *= _canvasHeightHalf;
+
+        renderSprite(_v1, element, material);
+      } else if (element instanceof THREE.RenderableLine) {
+        _v1 = element.v1; _v2 = element.v2;
+
+        _v1.positionScreen.x *= _canvasWidthHalf; _v1.positionScreen.y *= _canvasHeightHalf;
+        _v2.positionScreen.x *= _canvasWidthHalf; _v2.positionScreen.y *= _canvasHeightHalf;
+
+        _elemBox.setFromPoints([
+          _v1.positionScreen,
+          _v2.positionScreen,
+        ]);
+
+        if (_clipBox.intersectsBox(_elemBox) === true) {
+          renderLine(_v1, _v2, element, material);
+        }
+      } else if (element instanceof THREE.RenderableFace) {
+        _v1 = element.v1; _v2 = element.v2; _v3 = element.v3;
+
+        if (_v1.positionScreen.z < -1 || _v1.positionScreen.z > 1) continue;
+        if (_v2.positionScreen.z < -1 || _v2.positionScreen.z > 1) continue;
+        if (_v3.positionScreen.z < -1 || _v3.positionScreen.z > 1) continue;
+
+        _v1.positionScreen.x *= _canvasWidthHalf; _v1.positionScreen.y *= _canvasHeightHalf;
+        _v2.positionScreen.x *= _canvasWidthHalf; _v2.positionScreen.y *= _canvasHeightHalf;
+        _v3.positionScreen.x *= _canvasWidthHalf; _v3.positionScreen.y *= _canvasHeightHalf;
+
+        if (material.overdraw > 0) {
+          expand(_v1.positionScreen, _v2.positionScreen, material.overdraw);
+          expand(_v2.positionScreen, _v3.positionScreen, material.overdraw);
+          expand(_v3.positionScreen, _v1.positionScreen, material.overdraw);
+        }
+
+        _elemBox.setFromPoints([
+          _v1.positionScreen,
+          _v2.positionScreen,
+          _v3.positionScreen,
+        ]);
+
+        if (_clipBox.intersectsBox(_elemBox) === true) {
+          renderFace3(_v1, _v2, _v3, 0, 1, 2, element, material);
+        }
+      }
+
+      /* DEBUG
+			setLineWidth( 1 );
+			setStrokeStyle( 'rgba( 0, 255, 0, 0.5 )' );
+			_context.strokeRect( _elemBox.min.x, _elemBox.min.y, _elemBox.max.x - _elemBox.min.x, _elemBox.max.y - _elemBox.min.y );
+			*/
+
+      _clearBox.union(_elemBox);
+    }
+
+    /* DEBUG
+		setLineWidth( 1 );
+		setStrokeStyle( 'rgba( 255, 0, 0, 0.5 )' );
+		_context.strokeRect( _clearBox.min.x, _clearBox.min.y, _clearBox.max.x - _clearBox.min.x, _clearBox.max.y - _clearBox.min.y );
+		*/
+
+    _context.setTransform(1, 0, 0, 1, 0, 0);
+  };
+
+  //
+
+  function calculateLights() {
+    _ambientLight.setRGB(0, 0, 0);
+    _directionalLights.setRGB(0, 0, 0);
+    _pointLights.setRGB(0, 0, 0);
+
+    for (let l = 0, ll = _lights.length; l < ll; l++) {
+      const light = _lights[l];
+      const lightColor = light.color;
+
+      if (light.isAmbientLight) {
+        _ambientLight.add(lightColor);
+      } else if (light.isDirectionalLight) {
+        // for sprites
+
+        _directionalLights.add(lightColor);
+      } else if (light.isPointLight) {
+        // for sprites
+
+        _pointLights.add(lightColor);
+      }
+    }
+  }
+
+  function calculateLight(position, normal, color) {
+    for (let l = 0, ll = _lights.length; l < ll; l++) {
+      const light = _lights[l];
+
+      _lightColor.copy(light.color);
+
+      if (light.isDirectionalLight) {
+        var lightPosition = _vector3.setFromMatrixPosition(light.matrixWorld).normalize();
+
+        var amount = normal.dot(lightPosition);
+
+        if (amount <= 0) continue;
+
+        amount *= light.intensity;
+
+        color.add(_lightColor.multiplyScalar(amount));
+      } else if (light.isPointLight) {
+        var lightPosition = _vector3.setFromMatrixPosition(light.matrixWorld);
+
+        var amount = normal.dot(_vector3.subVectors(lightPosition, position).normalize());
+
+        if (amount <= 0) continue;
+
+        amount *= light.distance == 0 ? 1 : 1 - Math.min(position.distanceTo(lightPosition) / light.distance, 1);
+
+        if (amount == 0) continue;
+
+        amount *= light.intensity;
+
+        color.add(_lightColor.multiplyScalar(amount));
+      }
+    }
+  }
+
+  function renderSprite(v1, element, material) {
+    setOpacity(material.opacity);
+    setBlending(material.blending);
+
+    const scaleX = element.scale.x * _canvasWidthHalf;
+    const scaleY = element.scale.y * _canvasHeightHalf;
+
+    const dist = Math.sqrt(scaleX * scaleX + scaleY * scaleY); // allow for rotated sprite
+    _elemBox.min.set(v1.x - dist, v1.y - dist);
+    _elemBox.max.set(v1.x + dist, v1.y + dist);
+
+    if (material.isSpriteMaterial) {
+      const texture = material.map;
+
+      if (texture !== null) {
+        let pattern = _patterns[texture.id];
+
+        if (pattern === undefined || pattern.version !== texture.version) {
+          pattern = textureToPattern(texture);
+          _patterns[texture.id] = pattern;
+        }
+
+        if (pattern.canvas !== undefined) {
+          setFillStyle(pattern.canvas);
+
+          const bitmap = texture.image;
+
+          const ox = bitmap.width * texture.offset.x;
+          const oy = bitmap.height * texture.offset.y;
+
+          const sx = bitmap.width * texture.repeat.x;
+          const sy = bitmap.height * texture.repeat.y;
+
+          const cx = scaleX / sx;
+          const cy = scaleY / sy;
+
+          _context.save();
+          _context.translate(v1.x, v1.y);
+          if (material.rotation !== 0) _context.rotate(material.rotation);
+          _context.translate(-scaleX / 2, -scaleY / 2);
+          _context.scale(cx, cy);
+          _context.translate(-ox, -oy);
+          _context.fillRect(ox, oy, sx, sy);
+          _context.restore();
+        }
+      } else {
+        // no texture
+
+        setFillStyle(material.color.getStyle());
+
+        _context.save();
+        _context.translate(v1.x, v1.y);
+        if (material.rotation !== 0) _context.rotate(material.rotation);
+        _context.scale(scaleX, -scaleY);
+        _context.fillRect(-0.5, -0.5, 1, 1);
+        _context.restore();
+      }
+    } else if (material.isSpriteCanvasMaterial) {
+      setStrokeStyle(material.color.getStyle());
+      setFillStyle(material.color.getStyle());
+
+      _context.save();
+      _context.translate(v1.x, v1.y);
+      if (material.rotation !== 0) _context.rotate(material.rotation);
+      _context.scale(scaleX, scaleY);
+
+      material.program(_context);
+
+      _context.restore();
+    } else if (material.isPointsMaterial) {
+      setFillStyle(material.color.getStyle());
+
+      _context.save();
+      _context.translate(v1.x, v1.y);
+      if (material.rotation !== 0) _context.rotate(material.rotation);
+      _context.scale(scaleX * material.size, -scaleY * material.size);
+      _context.fillRect(-0.5, -0.5, 1, 1);
+      _context.restore();
+    }
+
+    /* DEBUG
+		setStrokeStyle( 'rgb(255,255,0)' );
+		_context.beginPath();
+		_context.moveTo( v1.x - 10, v1.y );
+		_context.lineTo( v1.x + 10, v1.y );
+		_context.moveTo( v1.x, v1.y - 10 );
+		_context.lineTo( v1.x, v1.y + 10 );
+		_context.stroke();
+		*/
+  }
+
+  function renderLine(v1, v2, element, material) {
+    setOpacity(material.opacity);
+    setBlending(material.blending);
+
+    _context.beginPath();
+    _context.moveTo(v1.positionScreen.x, v1.positionScreen.y);
+    _context.lineTo(v2.positionScreen.x, v2.positionScreen.y);
+
+    if (material.isLineBasicMaterial) {
+      setLineWidth(material.linewidth);
+      setLineCap(material.linecap);
+      setLineJoin(material.linejoin);
+
+      if (material.vertexColors !== THREE.VertexColors) {
+        setStrokeStyle(material.color.getStyle());
+      } else {
+        const colorStyle1 = element.vertexColors[0].getStyle();
+        const colorStyle2 = element.vertexColors[1].getStyle();
+
+        if (colorStyle1 === colorStyle2) {
+          setStrokeStyle(colorStyle1);
+        } else {
+          try {
+            var grad = _context.createLinearGradient(
+              v1.positionScreen.x,
+              v1.positionScreen.y,
+              v2.positionScreen.x,
+              v2.positionScreen.y,
+            );
+            grad.addColorStop(0, colorStyle1);
+            grad.addColorStop(1, colorStyle2);
+          } catch (exception) {
+            grad = colorStyle1;
+          }
+
+          setStrokeStyle(grad);
+        }
+      }
+
+      if (material.isLineDashedMaterial) {
+        setLineDash([material.dashSize, material.gapSize]);
+      }
+
+      _context.stroke();
+      _elemBox.expandByScalar(material.linewidth * 2);
+
+      if (material.isLineDashedMaterial) {
+        setLineDash([]);
+      }
+    }
+  }
+
+  function renderFace3(v1, v2, v3, uv1, uv2, uv3, element, material) {
+    _this.info.render.vertices += 3;
+    _this.info.render.faces++;
+
+    setOpacity(material.opacity);
+    setBlending(material.blending);
+
+    _v1x = v1.positionScreen.x; _v1y = v1.positionScreen.y;
+    _v2x = v2.positionScreen.x; _v2y = v2.positionScreen.y;
+    _v3x = v3.positionScreen.x; _v3y = v3.positionScreen.y;
+
+    drawTriangle(_v1x, _v1y, _v2x, _v2y, _v3x, _v3y);
+
+    if ((material.isMeshLambertMaterial || material.isMeshPhongMaterial || material.isMeshStandardMaterial) && material.map === null) {
+      _diffuseColor.copy(material.color);
+      _emissiveColor.copy(material.emissive);
+
+      if (material.vertexColors === THREE.FaceColors) {
+        _diffuseColor.multiply(element.color);
+      }
+
+      _color.copy(_ambientLight);
+
+      _centroid.copy(v1.positionWorld).add(v2.positionWorld).add(v3.positionWorld).divideScalar(3);
+
+      calculateLight(_centroid, element.normalModel, _color);
+
+      _color.multiply(_diffuseColor).add(_emissiveColor);
+
+      material.wireframe === true
+				 ? strokePath(_color, material.wireframeLinewidth, material.wireframeLinecap, material.wireframeLinejoin)
+				 : fillPath(_color);
+    } else if (material.isMeshBasicMaterial || material.isMeshLambertMaterial || material.isMeshPhongMaterial || material.isMeshStandardMaterial) {
+      if (material.map !== null) {
+        const mapping = material.map.mapping;
+
+        if (mapping === THREE.UVMapping) {
+          _uvs = element.uvs;
+          patternPath(_v1x, _v1y, _v2x, _v2y, _v3x, _v3y, _uvs[uv1].x, _uvs[uv1].y, _uvs[uv2].x, _uvs[uv2].y, _uvs[uv3].x, _uvs[uv3].y, material.map);
+        }
+      } else if (material.envMap !== null) {
+        if (material.envMap.mapping === THREE.SphericalReflectionMapping) {
+          _normal.copy(element.vertexNormalsModel[uv1]).applyMatrix3(_normalViewMatrix);
+          _uv1x = 0.5 * _normal.x + 0.5;
+          _uv1y = 0.5 * _normal.y + 0.5;
+
+          _normal.copy(element.vertexNormalsModel[uv2]).applyMatrix3(_normalViewMatrix);
+          _uv2x = 0.5 * _normal.x + 0.5;
+          _uv2y = 0.5 * _normal.y + 0.5;
+
+          _normal.copy(element.vertexNormalsModel[uv3]).applyMatrix3(_normalViewMatrix);
+          _uv3x = 0.5 * _normal.x + 0.5;
+          _uv3y = 0.5 * _normal.y + 0.5;
+
+          patternPath(_v1x, _v1y, _v2x, _v2y, _v3x, _v3y, _uv1x, _uv1y, _uv2x, _uv2y, _uv3x, _uv3y, material.envMap);
+        }
+      } else {
+        _color.copy(material.color);
+
+        if (material.vertexColors === THREE.FaceColors) {
+          _color.multiply(element.color);
+        }
+
+        material.wireframe === true
+					 ? strokePath(_color, material.wireframeLinewidth, material.wireframeLinecap, material.wireframeLinejoin)
+					 : fillPath(_color);
+      }
+    } else if (material.isMeshNormalMaterial) {
+      _normal.copy(element.normalModel).applyMatrix3(_normalViewMatrix);
+
+      _color.setRGB(_normal.x, _normal.y, _normal.z).multiplyScalar(0.5).addScalar(0.5);
+
+      material.wireframe === true
+				 ? strokePath(_color, material.wireframeLinewidth, material.wireframeLinecap, material.wireframeLinejoin)
+				 : fillPath(_color);
+    } else {
+      _color.setRGB(1, 1, 1);
+
+      material.wireframe === true
+				 ? strokePath(_color, material.wireframeLinewidth, material.wireframeLinecap, material.wireframeLinejoin)
+				 : fillPath(_color);
+    }
+  }
+
+  //
+
+  function drawTriangle(x0, y0, x1, y1, x2, y2) {
+    _context.beginPath();
+    _context.moveTo(x0, y0);
+    _context.lineTo(x1, y1);
+    _context.lineTo(x2, y2);
+    _context.closePath();
+  }
+
+  function strokePath(color, linewidth, linecap, linejoin) {
+    setLineWidth(linewidth);
+    setLineCap(linecap);
+    setLineJoin(linejoin);
+    setStrokeStyle(color.getStyle());
+
+    _context.stroke();
+
+    _elemBox.expandByScalar(linewidth * 2);
+  }
+
+  function fillPath(color) {
+    setFillStyle(color.getStyle());
+    _context.fill();
+  }
+
+  function textureToPattern(texture) {
+    if (texture.version === 0 ||
+			texture instanceof THREE.CompressedTexture ||
+			texture instanceof THREE.DataTexture) {
+      return {
+        canvas: undefined,
+        version: texture.version,
+      };
+    }
+
+    const image = texture.image;
+
+    if (image.complete === false) {
+      return {
+        canvas: undefined,
+        version: 0,
+      };
+    }
+
+    const repeatX = texture.wrapS === THREE.RepeatWrapping || texture.wrapS === THREE.MirroredRepeatWrapping;
+    const repeatY = texture.wrapT === THREE.RepeatWrapping || texture.wrapT === THREE.MirroredRepeatWrapping;
+
+    const mirrorX = texture.wrapS === THREE.MirroredRepeatWrapping;
+    const mirrorY = texture.wrapT === THREE.MirroredRepeatWrapping;
+
+    //
+
+    const canvas = document.createElement('canvas');
+    canvas.width = image.width * (mirrorX ? 2 : 1);
+    canvas.height = image.height * (mirrorY ? 2 : 1);
+
+    const context = canvas.getContext('2d');
+    context.setTransform(1, 0, 0, -1, 0, image.height);
+    context.drawImage(image, 0, 0);
+
+    if (mirrorX === true) {
+      context.setTransform(-1, 0, 0, -1, image.width, image.height);
+      context.drawImage(image, -image.width, 0);
+    }
+
+    if (mirrorY === true) {
+      context.setTransform(1, 0, 0, 1, 0, 0);
+      context.drawImage(image, 0, image.height);
+    }
+
+    if (mirrorX === true && mirrorY === true) {
+      context.setTransform(-1, 0, 0, 1, image.width, 0);
+      context.drawImage(image, -image.width, image.height);
+    }
+
+    let repeat = 'no-repeat';
+
+    if (repeatX === true && repeatY === true) {
+      repeat = 'repeat';
+    } else if (repeatX === true) {
+      repeat = 'repeat-x';
+    } else if (repeatY === true) {
+      repeat = 'repeat-y';
+    }
+
+    const pattern = _context.createPattern(canvas, repeat);
+
+    if (texture.onUpdate) texture.onUpdate(texture);
+
+    return {
+      canvas: pattern,
+      version: texture.version,
+    };
+  }
+
+  function patternPath(x0, y0, x1, y1, x2, y2, u0, v0, u1, v1, u2, v2, texture) {
+    let pattern = _patterns[texture.id];
+
+    if (pattern === undefined || pattern.version !== texture.version) {
+      pattern = textureToPattern(texture);
+      _patterns[texture.id] = pattern;
+    }
+
+    if (pattern.canvas !== undefined) {
+      setFillStyle(pattern.canvas);
+    } else {
+      setFillStyle('rgba( 0, 0, 0, 1)');
+      _context.fill();
+      return;
+    }
+
+    // http://extremelysatisfactorytotalitarianism.com/blog/?p=2120
+
+    let a,
+      b,
+      c,
+      d,
+      e,
+      f,
+      det,
+      idet,
+      offsetX = texture.offset.x / texture.repeat.x,
+      offsetY = texture.offset.y / texture.repeat.y,
+      width = texture.image.width * texture.repeat.x,
+      height = texture.image.height * texture.repeat.y;
+
+    u0 = (u0 + offsetX) * width;
+    v0 = (v0 + offsetY) * height;
+
+    u1 = (u1 + offsetX) * width;
+    v1 = (v1 + offsetY) * height;
+
+    u2 = (u2 + offsetX) * width;
+    v2 = (v2 + offsetY) * height;
+
+    x1 -= x0; y1 -= y0;
+    x2 -= x0; y2 -= y0;
+
+    u1 -= u0; v1 -= v0;
+    u2 -= u0; v2 -= v0;
+
+    det = u1 * v2 - u2 * v1;
+
+    if (det === 0) return;
+
+    idet = 1 / det;
+
+    a = (v2 * x1 - v1 * x2) * idet;
+    b = (v2 * y1 - v1 * y2) * idet;
+    c = (u1 * x2 - u2 * x1) * idet;
+    d = (u1 * y2 - u2 * y1) * idet;
+
+    e = x0 - a * u0 - c * v0;
+    f = y0 - b * u0 - d * v0;
+
+    _context.save();
+    _context.transform(a, b, c, d, e, f);
+    _context.fill();
+    _context.restore();
+  }
+
+  /*
+	function clipImage( x0, y0, x1, y1, x2, y2, u0, v0, u1, v1, u2, v2, image ) {
+
+		// http://extremelysatisfactorytotalitarianism.com/blog/?p=2120
+
+		var a, b, c, d, e, f, det, idet,
+		width = image.width - 1,
+		height = image.height - 1;
+
+		u0 *= width; v0 *= height;
+		u1 *= width; v1 *= height;
+		u2 *= width; v2 *= height;
+
+		x1 -= x0; y1 -= y0;
+		x2 -= x0; y2 -= y0;
+
+		u1 -= u0; v1 -= v0;
+		u2 -= u0; v2 -= v0;
+
+		det = u1 * v2 - u2 * v1;
+
+		idet = 1 / det;
+
+		a = ( v2 * x1 - v1 * x2 ) * idet;
+		b = ( v2 * y1 - v1 * y2 ) * idet;
+		c = ( u1 * x2 - u2 * x1 ) * idet;
+		d = ( u1 * y2 - u2 * y1 ) * idet;
+
+		e = x0 - a * u0 - c * v0;
+		f = y0 - b * u0 - d * v0;
+
+		_context.save();
+		_context.transform( a, b, c, d, e, f );
+		_context.clip();
+		_context.drawImage( image, 0, 0 );
+		_context.restore();
+
+	}
+	*/
+
+  // Hide anti-alias gaps
+
+  function expand(v1, v2, pixels) {
+    let x = v2.x - v1.x,
+      y = v2.y - v1.y,
+      det = x * x + y * y,
+      idet;
+
+    if (det === 0) return;
+
+    idet = pixels / Math.sqrt(det);
+
+    x *= idet; y *= idet;
+
+    v2.x += x; v2.y += y;
+    v1.x -= x; v1.y -= y;
+  }
+
+  // Context cached methods.
+
+  function setOpacity(value) {
+    if (_contextGlobalAlpha !== value) {
+      _context.globalAlpha = value;
+      _contextGlobalAlpha = value;
+    }
+  }
+
+  function setBlending(value) {
+    if (_contextGlobalCompositeOperation !== value) {
+      if (value === THREE.NormalBlending) {
+        _context.globalCompositeOperation = 'source-over';
+      } else if (value === THREE.AdditiveBlending) {
+        _context.globalCompositeOperation = 'lighter';
+      } else if (value === THREE.SubtractiveBlending) {
+        _context.globalCompositeOperation = 'darker';
+      } else if (value === THREE.MultiplyBlending) {
+        _context.globalCompositeOperation = 'multiply';
+      }
+
+      _contextGlobalCompositeOperation = value;
+    }
+  }
+
+  function setLineWidth(value) {
+    if (_contextLineWidth !== value) {
+      _context.lineWidth = value;
+      _contextLineWidth = value;
+    }
+  }
+
+  function setLineCap(value) {
+    // "butt", "round", "square"
+
+    if (_contextLineCap !== value) {
+      _context.lineCap = value;
+      _contextLineCap = value;
+    }
+  }
+
+  function setLineJoin(value) {
+    // "round", "bevel", "miter"
+
+    if (_contextLineJoin !== value) {
+      _context.lineJoin = value;
+      _contextLineJoin = value;
+    }
+  }
+
+  function setStrokeStyle(value) {
+    if (_contextStrokeStyle !== value) {
+      _context.strokeStyle = value;
+      _contextStrokeStyle = value;
+    }
+  }
+
+  function setFillStyle(value) {
+    if (_contextFillStyle !== value) {
+      _context.fillStyle = value;
+      _contextFillStyle = value;
+    }
+  }
+
+  function setLineDash(value) {
+    if (_contextLineDash.length !== value.length) {
+      _context.setLineDash(value);
+      _contextLineDash = value;
+    }
+  }
+};

--- a/src/three.js
+++ b/src/three.js
@@ -1,5 +1,5 @@
 global.THREE = require('three');
-require('three/examples/js/renderers/CanvasRenderer');
+require('./CanvasRenderer');
 require('three/examples/js/renderers/Projector');
 
 export default global.THREE;

--- a/src/toCanvas.js
+++ b/src/toCanvas.js
@@ -1,4 +1,4 @@
-import Canvas from 'canvas';
+import { createCanvas } from 'canvas';
 
 import THREE from './three';
 
@@ -30,7 +30,7 @@ export default function toCanvas(scene, options) {
     camera.lookAt(outScene.position);
   }
 
-  const canvas = new Canvas(opts.width, opts.height);
+  const canvas = createCanvas(opts.width, opts.height);
   canvas.style = {}; // dummy shim to prevent errors during render.setSize
   const renderer = new THREE.CanvasRenderer({ canvas });
   renderer.setSize(opts.width, opts.height);


### PR DESCRIPTION
Hello @dbkaplun,

Thank you very much for this package

I'd like to combine jsdom with node-three-screenshot but jsdom requires to canvas 2.x to work with loaders.
I suggest to update three and canvas version in the package.

I add to put canvasRenderer inside node-three-screenshot package cause it has been removed from last threejs version, i think it makes sense anyway to keep it here.

Please share your feedbacks